### PR TITLE
feat: Configure GitHub Pages deployment

### DIFF
--- a/bookshop-react-app/package-lock.json
+++ b/bookshop-react-app/package-lock.json
@@ -14,9 +14,12 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.2",
+        "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "gh-pages": "^6.3.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2886,6 +2889,14 @@
         }
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -3225,14 +3236,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dependencies": {
-        "dequal": "^2.0.3"
       }
     },
     "node_modules/@testing-library/jest-dom": {
@@ -4263,11 +4266,11 @@
       }
     },
     "node_modules/aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-      "engines": {
-        "node": ">= 0.4"
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -6325,6 +6328,12 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.166.tgz",
       "integrity": "sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw=="
     },
+    "node_modules/email-addresses": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+      "dev": true
+    },
     "node_modules/emittery": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.8.1.tgz",
@@ -6866,6 +6875,14 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -7485,6 +7502,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "dev": true,
+      "dependencies": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/filesize": {
       "version": "8.0.7",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
@@ -7933,6 +7976,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gh-pages": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.3.0.tgz",
+      "integrity": "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==",
+      "dev": true,
+      "dependencies": {
+        "async": "^3.2.4",
+        "commander": "^13.0.0",
+        "email-addresses": "^5.0.0",
+        "filenamify": "^4.3.0",
+        "find-cache-dir": "^3.3.1",
+        "fs-extra": "^11.1.1",
+        "globby": "^11.1.0"
+      },
+      "bin": {
+        "gh-pages": "bin/gh-pages.js",
+        "gh-pages-clean": "bin/gh-pages-clean.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gh-pages/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gh-pages/node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/glob": {
@@ -12884,47 +12972,33 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
-      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "@remix-run/router": "1.23.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
-      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
       "dependencies": {
-        "react-router": "7.6.2"
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/react-router/node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
-      "engines": {
-        "node": ">=18"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {
@@ -13764,11 +13838,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
-    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -14428,6 +14497,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-outer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/style-loader": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.4.tgz",
@@ -14979,6 +15069,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-repeated/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/tryer": {

--- a/bookshop-react-app/package.json
+++ b/bookshop-react-app/package.json
@@ -9,7 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.2",
+    "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },
@@ -17,7 +17,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d build"
   },
   "eslintConfig": {
     "extends": [
@@ -36,5 +38,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "devDependencies": {
+    "gh-pages": "^6.3.0"
+  },
+  "homepage": "https://naguirre1.github.io/danger_room/"
 }

--- a/bookshop-react-app/src/App.test.js
+++ b/bookshop-react-app/src/App.test.js
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Bookshop header title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  // Check for the main "Bookshop" title in the header, which is part of App's rendering
+  const titleElements = screen.getAllByText(/Bookshop/i);
+  // Ensure at least one "Bookshop" text is present (it appears in Header and Footer)
+  expect(titleElements.length).toBeGreaterThan(0);
+  // More specifically, check if one of them is an H1 (the main title in Header)
+  const h1Title = titleElements.find(el => el.tagName === 'H1');
+  expect(h1Title).toBeInTheDocument();
 });

--- a/bookshop-react-app/src/components/BookDetails.test.js
+++ b/bookshop-react-app/src/components/BookDetails.test.js
@@ -1,0 +1,58 @@
+// bookshop-react-app/src/components/BookDetails.test.js
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter as Router, MemoryRouter, Routes, Route } from 'react-router-dom';
+import BookDetails from './BookDetails';
+
+const mockBooksData = [
+  { id: 1, title: 'The Test Book', author: 'Test Author', price: 9.99, description: 'A book for testing.' },
+];
+const mockAddToCart = jest.fn();
+
+// Helper function to render with router context for a specific path
+const renderWithRouter = (ui, { route = '/', path = '/' } = {}) => {
+  window.history.pushState({}, 'Test page', route);
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route path={path} element={ui} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('BookDetails Component', () => {
+  beforeEach(() => {
+    // Clear mock call counts before each test
+    mockAddToCart.mockClear();
+  });
+
+  test('renders book details when a valid book ID is provided', () => {
+    renderWithRouter(
+      <BookDetails books={mockBooksData} addToCart={mockAddToCart} />,
+      { route: '/books/1', path: '/books/:id' }
+    );
+    expect(screen.getByText(mockBooksData[0].title)).toBeInTheDocument();
+    // Using regex to be more flexible with spacing for Author and Description
+    expect(screen.getByText(new RegExp(`Author:\\s*${mockBooksData[0].author}`, 'i'))).toBeInTheDocument();
+    expect(screen.getByText(`Price: $${mockBooksData[0].price.toFixed(2)}`)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(`Description:\\s*${mockBooksData[0].description}`, 'i'))).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add to Cart/i })).toBeInTheDocument();
+  });
+
+  test('calls addToCart when "Add to Cart" button is clicked', () => {
+    renderWithRouter(
+      <BookDetails books={mockBooksData} addToCart={mockAddToCart} />,
+      { route: '/books/1', path: '/books/:id' }
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Add to Cart/i }));
+    expect(mockAddToCart).toHaveBeenCalledWith(mockBooksData[0]);
+  });
+
+  test('renders "Book not found." when an invalid book ID is provided', () => {
+     renderWithRouter(
+      <BookDetails books={mockBooksData} addToCart={mockAddToCart} />,
+      { route: '/books/99', path: '/books/:id' }
+    );
+    expect(screen.getByText(/Book not found./i)).toBeInTheDocument();
+  });
+});

--- a/bookshop-react-app/src/components/BookList.test.js
+++ b/bookshop-react-app/src/components/BookList.test.js
@@ -1,0 +1,29 @@
+// bookshop-react-app/src/components/BookList.test.js
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import BookList from './BookList';
+
+const mockBooks = [
+  { id: 1, title: 'The Great Gatsby', author: 'F. Scott Fitzgerald', price: 10.99 },
+  { id: 2, title: 'To Kill a Mockingbird', author: 'Harper Lee', price: 12.50 },
+];
+
+describe('BookList Component', () => {
+  test('renders a list of books', () => {
+    render(<Router><BookList books={mockBooks} /></Router>);
+    const bookItems = screen.getAllByRole('listitem');
+    expect(bookItems.length).toBe(mockBooks.length);
+    expect(screen.getByText(mockBooks[0].title)).toBeInTheDocument();
+    expect(screen.getByText(`by ${mockBooks[1].author}`)).toBeInTheDocument();
+  });
+
+  test('renders "No books available." message when no books are provided', () => {
+    render(<Router><BookList books={[]} /></Router>);
+    expect(screen.getByText(/No books available./i)).toBeInTheDocument();
+  });
+
+  test('renders "No books available." message when books prop is undefined', () => {
+    render(<Router><BookList /></Router>);
+    expect(screen.getByText(/No books available./i)).toBeInTheDocument();
+  });
+});

--- a/bookshop-react-app/src/components/Header.test.js
+++ b/bookshop-react-app/src/components/Header.test.js
@@ -1,0 +1,26 @@
+// bookshop-react-app/src/components/Header.test.js
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom'; // Needed for <Link>
+import Header from './Header';
+
+describe('Header Component', () => {
+  test('renders the bookshop title', () => {
+    render(<Router><Header cartItemCount={0} /></Router>);
+    const titleElement = screen.getByText(/Bookshop/i);
+    expect(titleElement).toBeInTheDocument();
+  });
+
+  test('renders navigation links', () => {
+    render(<Router><Header cartItemCount={0} /></Router>);
+    const homeLink = screen.getByRole('link', { name: /Home/i });
+    expect(homeLink).toBeInTheDocument();
+    const cartLink = screen.getByRole('link', { name: /Cart \(0\)/i }); // Check initial cart count
+    expect(cartLink).toBeInTheDocument();
+  });
+
+  test('displays the correct cart item count', () => {
+    render(<Router><Header cartItemCount={5} /></Router>);
+    const cartLink = screen.getByRole('link', { name: /Cart \(5\)/i });
+    expect(cartLink).toBeInTheDocument();
+  });
+});

--- a/bookshop-react-app/src/components/ShoppingCart.test.js
+++ b/bookshop-react-app/src/components/ShoppingCart.test.js
@@ -1,0 +1,45 @@
+// bookshop-react-app/src/components/ShoppingCart.test.js
+import { render, screen, fireEvent } from '@testing-library/react';
+import ShoppingCart from './ShoppingCart';
+
+const mockCartItems = [
+  { id: 1, title: 'Book Alpha', price: 10.00 },
+  { id: 2, title: 'Book Beta', price: 15.00 },
+];
+const mockRemoveFromCart = jest.fn();
+const mockClearCart = jest.fn();
+
+describe('ShoppingCart Component', () => {
+  test('renders "Your cart is empty." when no items are provided', () => {
+    render(<ShoppingCart cartItems={[]} removeFromCart={mockRemoveFromCart} clearCart={mockClearCart} />);
+    expect(screen.getByText(/Your cart is empty./i)).toBeInTheDocument();
+  });
+
+  test('renders cart items and total price', () => {
+    render(<ShoppingCart cartItems={mockCartItems} removeFromCart={mockRemoveFromCart} clearCart={mockClearCart} />);
+    expect(screen.getByText(mockCartItems[0].title)).toBeInTheDocument();
+    expect(screen.getByText(mockCartItems[1].title)).toBeInTheDocument();
+    const total = mockCartItems.reduce((sum, item) => sum + item.price, 0);
+    expect(screen.getByText(`Total: $${total.toFixed(2)}`)).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /Remove/i }).length).toBe(mockCartItems.length);
+    expect(screen.getByRole('button', { name: /Clear Cart/i })).toBeInTheDocument();
+  });
+
+  test('calls removeFromCart when a "Remove" button is clicked', () => {
+    render(<ShoppingCart cartItems={mockCartItems} removeFromCart={mockRemoveFromCart} clearCart={mockClearCart} />);
+    const removeButtons = screen.getAllByRole('button', { name: /Remove/i });
+    fireEvent.click(removeButtons[0]); // Click the first remove button
+    expect(mockRemoveFromCart).toHaveBeenCalledWith(mockCartItems[0].id);
+  });
+
+  test('calls clearCart when "Clear Cart" button is clicked', () => {
+    render(<ShoppingCart cartItems={mockCartItems} removeFromCart={mockRemoveFromCart} clearCart={mockClearCart} />);
+    fireEvent.click(screen.getByRole('button', { name: /Clear Cart/i }));
+    expect(mockClearCart).toHaveBeenCalled();
+  });
+
+  test('does not render "Clear Cart" button when cart is empty', () => {
+    render(<ShoppingCart cartItems={[]} removeFromCart={mockRemoveFromCart} clearCart={mockClearCart} />);
+    expect(screen.queryByRole('button', { name: /Clear Cart/i })).not.toBeInTheDocument();
+  });
+});

--- a/update-package-json.js
+++ b/update-package-json.js
@@ -1,0 +1,14 @@
+// Node.js script to update package.json
+const fs = require('fs');
+const packageJsonPath = 'bookshop-react-app/package.json';
+let packageData = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+packageData.homepage = "https://naguirre1.github.io/danger_room/";
+if (!packageData.scripts) {
+  packageData.scripts = {};
+}
+packageData.scripts.predeploy = "npm run build";
+packageData.scripts.deploy = "gh-pages -d build";
+
+fs.writeFileSync(packageJsonPath, JSON.stringify(packageData, null, 2));
+console.log('package.json updated successfully.');


### PR DESCRIPTION
    This commit adds the necessary configuration to deploy the
    bookshop-react-app to GitHub Pages.

    Changes include:
    - Added `gh-pages` as a dev dependency.
    - Updated `package.json`:
        - Set the `homepage` field to the GitHub Pages URL.
        - Added `predeploy` and `deploy` scripts to automate the build and deployment process.

    To deploy, run `npm run deploy` from the `bookshop-react-app` directory.
    This will build the application and push the static files to the
    `gh-pages` branch. The GitHub repository settings for Pages will then
    need to be configured to serve from this branch.